### PR TITLE
Add required imports whenever is necessary

### DIFF
--- a/src/codegen/cbor/imports.ts
+++ b/src/codegen/cbor/imports.ts
@@ -1,0 +1,8 @@
+export const getCborImports = (stateClassName: string): string => {
+    const imports = `
+        import {CBOREncoder, CBORDecoder} from "@zondax/assemblyscript-cbor/assembly"
+        import {Value, Arr, Str, Integer, Obj, Float, Bytes} from "@zondax/assemblyscript-cbor/assembly/types"
+    `
+
+    return imports
+}

--- a/src/codegen/state/index.ts
+++ b/src/codegen/state/index.ts
@@ -27,19 +27,6 @@ export function getStateEncodeFunc(fields: string[]) {
     return result
 }
 
-export const getStateImports = (stateClassName: string) => {
-    const imports = `
-        import {CBOREncoder, CBORDecoder} from "@zondax/assemblyscript-cbor/assembly"
-        import {Value, Arr, Str, Integer, Obj, Float, Bytes} from "@zondax/assemblyscript-cbor/assembly/types"
-        
-        import {Cid, DAG_CBOR} from "@zondax/fvm-as-sdk/assembly/env";
-        import {Get, Put, root} from "@zondax/fvm-as-sdk/assembly/helpers";
-        import {setRoot} from "@zondax/fvm-as-sdk/assembly/wrappers";
-    `
-
-    return imports
-}
-
 export const getStateStaticFuncs = (stateClassName: string, fields: string[]): string => {
     const func = `static defaultState(): ${stateClassName} {
         return new ${stateClassName}( __params__ );


### PR DESCRIPTION
If custom classes are located on files outside index or state, compilation will fail because of the lack of some required imports. This PR fixes it.

<!-- ClickUpRef: 2pc1k2f -->
:link: [zboto Link](https://app.clickup.com/t/2pc1k2f)